### PR TITLE
Avoid spurious entries in jump list

### DIFF
--- a/plugin/matchit.vim
+++ b/plugin/matchit.vim
@@ -257,8 +257,8 @@ function! s:Match_wrapper(word, forward, mode) range
   let restore_cursor = virtcol(".") . "|"
   normal! g0
   let restore_cursor = line(".") . "G" .  virtcol(".") . "|zs" . restore_cursor
-  normal! H
-  let restore_cursor = "normal!" . line(".") . "Gzt" . restore_cursor
+  keepjumps normal! H
+  let restore_cursor = "keepjumps normal!" . line(".") . "Gzt" . restore_cursor
   execute restore_cursor
   call cursor(0, curcol + 1)
   " normal! 0
@@ -695,13 +695,13 @@ fun! s:MultiMatch(spflag, mode)
   endif
   let skip = s:ParseSkip(skip)
   " let restore_cursor = line(".") . "G" . virtcol(".") . "|"
-  " normal! H
+  " keepjumps normal! H
   " let restore_cursor = "normal!" . line(".") . "Gzt" . restore_cursor
   let restore_cursor = virtcol(".") . "|"
   normal! g0
   let restore_cursor = line(".") . "G" .  virtcol(".") . "|zs" . restore_cursor
-  normal! H
-  let restore_cursor = "normal!" . line(".") . "Gzt" . restore_cursor
+  keepjumps normal! H
+  let restore_cursor = "keepjumps normal!" . line(".") . "Gzt" . restore_cursor
   execute restore_cursor
 
   " Third step: call searchpair().


### PR DESCRIPTION
This commit adds a few `keepjumps` annotations to some commands. This prevents polluting the jumplist with intermediate positions from the internal computations of the plugin, which in turn helps when navigating the buffer with `<CTRL-O>` and `<CTRL-I>`.
