### PR TITLE
level is set to incorrect value after 'execute restore_cursor' is called

### DIFF
--- a/plugin/matchit.vim
+++ b/plugin/matchit.vim
@@ -186,7 +186,9 @@ function! s:Match_wrapper(word, forward, mode) range
     let curcol = match(matchline, regexp)
     " If there is no match, give up.
     if curcol == -1
-      return s:CleanUp(restore_options, a:mode, startline, startcol)
+      " HF: if there is no valid match, go to the closest end of pair
+      call s:CleanUp(restore_options, a:mode, startline, startcol)
+      return s:MultiMatch("W", "n")
     endif
     let endcol = matchend(matchline, regexp)
     let suf = strlen(matchline) - endcol

--- a/plugin/matchit.vim
+++ b/plugin/matchit.vim
@@ -706,6 +706,9 @@ fun! s:MultiMatch(spflag, mode)
   else
     let skip = 's:comment\|string'
   endif
+  " HF: 'execute restore_cursor' will change v:count1, we need to get the
+  " original vcount before it's changed 
+  let level = v:count1
   let skip = s:ParseSkip(skip)
   " let restore_cursor = line(".") . "G" . virtcol(".") . "|"
   " normal! H
@@ -729,7 +732,6 @@ fun! s:MultiMatch(spflag, mode)
     execute "if " . skip . "| let skip = '0' | endif"
   endif
   mark '
-  let level = v:count1
   while level
     if searchpair(openpat, '', closepat, a:spflag, skip) < 1
       call s:CleanUp(restore_options, a:mode, startline, startcol)


### PR DESCRIPTION
## What happened?

``` objc
- (NSNumber*)numberForKey:(NSString *)key defaultRule:(id)d
{
    for (HFTAGContainer* container in self.containers) {
        NSNumber* number = [container numberForKey:key defaultRule:d];

        if (number) {
            return number;
        }
    }
    // type ]% in normal mode here
    return d;
}

@end // will jump to here
```
## Expected

``` objc
- (NSNumber*)numberForKey:(NSString *)key defaultRule:(id)d
{
    for (HFTAGContainer* container in self.containers) {
        NSNumber* number = [container numberForKey:key defaultRule:d];

        if (number) {
            return number;
        }
    }
    // type ]% in normal mode here
    return d;
} // will jump to here

@end 
```
## What's fixed?

In above example, `v:count1` should be 1.
But I traced the code, and found out that `v:count` becomes 5 after `execute restore_cursor`.
So I move `let level = v:count1` to the location before `restore_cursor`
