### PR TITLE
If there is no valid match, go to the closest end of pair

### DIFF
--- a/plugin/matchit.vim
+++ b/plugin/matchit.vim
@@ -186,7 +186,9 @@ function! s:Match_wrapper(word, forward, mode) range
     let curcol = match(matchline, regexp)
     " If there is no match, give up.
     if curcol == -1
-      return s:CleanUp(restore_options, a:mode, startline, startcol)
+      " HF: if there is no valid match, go to the closest end of pair
+      call s:CleanUp(restore_options, a:mode, startline, startcol)
+      return s:MultiMatch("W", "n")
     endif
     let endcol = matchend(matchline, regexp)
     let suf = strlen(matchline) - endcol


### PR DESCRIPTION
This is an opinionated request.
It is quite frustrating when `%` does nothing.
## What happened?

``` c
void myFunc()
{

// type % will do nothing


}
```
## Expected

``` c
void myFunc()
{

// type % will jump to }


} // will jump to here
```
## What did I do?

call `]%` when there is no action for `%`
