### PR TITLE
Fix multibyte problem in operater pending mode

### DIFF
--- a/plugin/matchit.vim
+++ b/plugin/matchit.vim
@@ -316,7 +316,7 @@ fun! s:CleanUp(options, mode, startline, startcol, ...)
       let regexp = s:Wholematch(matchline, a:1, currcol-1)
       let endcol = matchend(matchline, regexp)
       if endcol > currcol  " This is NOT off by one!
-	execute "normal!" . (endcol - currcol) . "l"
+	call cursor(0, endcol)
       endif
     endif " a:0
   endif " a:mode != "o" && etc.


### PR DESCRIPTION
`%` in Operator pending mode doesn't work properly when multibyte
characters are set in `b:match_words`.

E.g. consider setting `（` (`U+FF08`, FULLWIDTH LEFT PARENTHESIS) and
`）` (`U+FF09`, FULLWIDTH RIGHT PARENTHESIS) as a pair.

Step to reproduce:
1. Execute vim with the following command line
   
   ```
   vim -u NONE -N -c 'runtime macros/matchit.vim' -c 'let b:match_words="（:）"'
   ```
2. Insert the following text
   
   ```
   aaa（bbb）ccc
   ```
3. Move the cursor on `（`, then type `d%`
   
   Actual result is:
   
   ```
   aaac
   ```
   
   Expected result is:
   
   ```
   aaaccc
   ```

This is caused in `s:CleanUp()`. Character count should be used instead of
byte count.

See also:
https://groups.google.com/d/msg/vim_dev/KF2jc0NKzL8/SEa-Qr1BQ8AJ

This fix is already merged into the official Vim repository:
https://github.com/vim/vim/commit/fc39ecf8ded5466d7e9cbde8db75517718b023d8
