### PR TITLE
Allow forcing a motion to be linewise (dV% works)

### DIFF
--- a/doc/matchit.txt
+++ b/doc/matchit.txt
@@ -73,11 +73,9 @@ for how to specify matching patterns.
 MODES:			*matchit-modes* *matchit-v_%* *matchit-o_%*
 
 Mostly, % and related motions (|g%| and |[%| and |]%|) work just like built-in
-|motion| commands in |Operator-pending| and |Visual| modes.  However, you
-cannot make these motions |linewise| or |characterwise|, since the |:omap|s
-that define them start with "v" in order to make the default behavior
-inclusive.  (See |o_v|.)  In other words, "dV%" will not work.  The
-work-around is to go through Visual mode:  "V%d" will work.
+|motion| commands in |Operator-pending| and |Visual| modes; the default behavior
+of these motions is inclusive. However, you can make these motions |linewise|.
+(See |o_V|.)  In other words, "dV%" will work.
 
 LANGUAGES:					*matchit-languages*
 

--- a/plugin/matchit.vim
+++ b/plugin/matchit.vim
@@ -52,21 +52,27 @@ nnoremap <silent> <Plug>MatchitNormalBackward    :<C-U>call <SID>Match_wrapper('
 vnoremap <silent> <Plug>MatchitVisualForward     :<C-U>call <SID>Match_wrapper('',1,'v')<CR>m'gv``
 vnoremap <silent> <Plug>MatchitVisualBackward    :<C-U>call <SID>Match_wrapper('',0,'v')<CR>m'gv``
 onoremap <silent> <Plug>MatchitOperationForward  v:<C-U>call <SID>Match_wrapper('',1,'o')<CR>
+onoremap <silent> <Plug>MatchitLWOperationForward  V:<C-U>call <SID>Match_wrapper('',1,'o')<CR>
 onoremap <silent> <Plug>MatchitOperationBackward v:<C-U>call <SID>Match_wrapper('',0,'o')<CR>
+onoremap <silent> <Plug>MatchitLWOperationBackward V:<C-U>call <SID>Match_wrapper('',0,'o')<CR>
 
 nmap <silent> %  <Plug>MatchitNormalForward
 nmap <silent> g% <Plug>MatchitNormalBackward
 vmap <silent> %  <Plug>MatchitVisualForward
 vmap <silent> g% <Plug>MatchitVisualBackward
 omap <silent> %  <Plug>MatchitOperationForward
+omap <silent> V%  <Plug>MatchitLWOperationForward
 omap <silent> g% <Plug>MatchitOperationBackward
+omap <silent> Vg% <Plug>MatchitLWOperationBackward
 
 " Analogues of [{ and ]} using matching patterns:
 nnoremap <silent> <Plug>MatchitNormalMultiBackward :<C-U>call <SID>MultiMatch("bW", "n")<CR>
 nnoremap <silent> <Plug>MatchitNormalMultiForward  :<C-U>call <SID>MultiMatch("W",  "n")<CR>
 vnoremap <silent> <Plug>MatchitVisualMultiBackward :<C-U>call <SID>MultiMatch("bW", "n") <CR>m'gv``
 vnoremap <silent> <Plug>MatchitVisualMultiForward  :<C-U>call <SID>MultiMatch("W",  "n") <CR>m'gv``
+onoremap <silent> <Plug>MatchitLWOperationMultiBackward V:<C-U>call <SID>MultiMatch("bW", "o")<CR>
 onoremap <silent> <Plug>MatchitOperationMultiBackward v:<C-U>call <SID>MultiMatch("bW", "o")<CR>
+onoremap <silent> <Plug>MatchitLWOperationMultiForward  V:<C-U>call <SID>MultiMatch("W",  "o")<CR>
 onoremap <silent> <Plug>MatchitOperationMultiForward  v:<C-U>call <SID>MultiMatch("W",  "o")<CR>
 
 nmap <silent> [% <Plug>MatchitNormalMultiBackward
@@ -74,7 +80,9 @@ nmap <silent> ]% <Plug>MatchitNormalMultiForward
 vmap <silent> [% <Plug>MatchitVisualMultiBackward
 vmap <silent> ]% <Plug>MatchitVisualMultiForward
 omap <silent> [% <Plug>MatchitOperationMultiBackward
+omap <silent> V[% <Plug>MatchitLWOperationMultiBackward
 omap <silent> ]% <Plug>MatchitOperationMultiForward
+omap <silent> V]% <Plug>MatchitLWOperationMultiForward
 
 " text object:
 vnoremap <silent> <Plug>MatchitVisualTextObject <Plug>MatchitVisualMultiBackward<Plug>MatchitVisualMultiForward


### PR DESCRIPTION
Despite there is as workaround (`V%d`), I keep forgetting it.
I've performed some small tests and found no side-effects. 
